### PR TITLE
fix #23: normalize $appname with maxlength 32 + change buggy permissions

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -38,10 +38,8 @@ parent_dir=/var/www/webapp_$admin
 
 # use as base for the directory and appname the domain and path and normalize it
 # so it can be used as a unix username (no . nor - and max 32 chars)
-cutted_domain="$(echo ${domain//-/_} | cut -c 1-15)"
-cutted_domain=${cutted_domain//./_}
-cutted_path="$(echo $path_url | cut -d '/' -f 2 | cut -c 1-8)"
-directory="${cutted_domain}_${cutted_path}"
+directory="$(echo ${domain//[-.]/_} | cut -c 1-15)_\
+$(echo $path_url | cut -d '/' -f 2 | cut -c 1-8)"
 appname=webapp_$directory # maxlength = 7 + 16 + 9 = 32
 
 final_path=$parent_dir/$directory

--- a/scripts/install
+++ b/scripts/install
@@ -35,8 +35,15 @@ app=$YNH_APP_INSTANCE_NAME
 ynh_script_progression --message="Check if the app can be installed"
 
 parent_dir=/var/www/webapp_$admin
-directory="${domain//-/_}_$(echo $path_url | cut -d '/' -f 2)"
-appname=webapp_$directory
+
+# use as base for the directory and appname the domain and path and normalize it
+# so it can be used as a unix username (no . nor - and max 32 chars)
+cutted_domain="$(echo ${domain//-/_} | cut -c 1-15)"
+cutted_domain=${cutted_domain//./_}
+cutted_path="$(echo $path_url | cut -d '/' -f 2 | cut -c 1-8)"
+directory="${cutted_domain}_${cutted_path}"
+appname=webapp_$directory # maxlength = 7 + 16 + 9 = 32
+
 final_path=$parent_dir/$directory
 # For this app; $app is the label, as usual, but $appname will contains the real name of the app, from the path.
 test ! -e "$final_path" || ynh_die "This path already contains a folder"
@@ -183,7 +190,7 @@ ynh_replace_string "__APPNAME__" "$appname" "$finalnginxconf"
 
 # Set permissions to app files
 chmod 775 -R $final_path
-chown -R $admin:$appname $final_path
+chown -R $appname:$appname $final_path
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
### Fix #23 : double cut directory name (max length 32) to avoid unix user creation bug

I added two cut step in the directory name generation : one to cut the domain to max 13 chars the other to cut the path to max 12 chars.

Adding the `webapp_` prefix make the length max 32 chars long and it should avoid name collision since it still use domain and path as a base.

Also I added a new substitution of `.` by `_` to make the name snakecase.

I fixed an error I encountered installing the app because `chown -R $admin:$appname $final_path` causes chown `invalid argument` error.